### PR TITLE
Fix AWX KeyError on plugin discovery and add automated test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,11 @@ safeguard-ansible/
 │   └── build-credplugin-steps.yml       # Credential plugin build steps
 ├── collection/                          # Ansible Galaxy collection
 │   ├── azure-pipelines.yml              # Collection CI/CD pipeline
-│   ├── tests/                           # Automated integration test suite
+│   ├── tests/                           # Automated test suite
 │   │   ├── pytest.ini                   # Pytest config & markers
 │   │   ├── requirements.txt             # Test dependencies
 │   │   ├── conftest.py                  # Session fixtures, playbook runner, auto-skip
+│   │   ├── test_unit.py                 # Unit tests (32 tests, no appliance needed)
 │   │   ├── test_safeguardcredentials.py # A2A lookup plugin tests (8 tests)
 │   │   ├── test_safeguardaccessrequest.py # Access request plugin tests (10 tests)
 │   │   ├── test_tls_verification.py    # TLS certificate verification tests (3 tests)
@@ -152,14 +153,30 @@ python3 -m build
 
 ## Testing
 
-### Automated integration tests (lookup plugins)
+### Unit tests (collection lookup plugins)
+
+The collection has unit tests that exercise helper functions and logic
+without requiring a live appliance or Ansible. Tests are in
+`collection/tests/test_unit.py`.
+
+```bash
+cd collection/tests
+python3 -m pytest test_unit.py -v
+```
+
+**Coverage** (32 tests): `_resolve_verify` mapping, `_find_entitlement`
+matching/filtering/error handling, `_find_existing_request` state logic,
+`_checkout_with_retry` retry/timeout, `_create_or_reuse_request` success/reuse/error,
+and `validate_certs` string normalization.
+
+### Integration tests (collection lookup plugins)
 
 The collection has a pytest-based integration test suite that runs against a
 live SPP appliance. Tests are in `collection/tests/`.
 
 **Prerequisites**: Python ≥ 3.10, `pip install -r collection/tests/requirements.txt`
 
-**Running**:
+**Running all tests** (unit tests always run, integration tests require `SPP_HOST`):
 
 ```bash
 cd collection/tests
@@ -174,14 +191,15 @@ SPP_HOST=<appliance-ip> SPP_ADMIN_PASSWORD=<admin-pw> python3 -m pytest -v
 | `SPP_ADMIN_PASSWORD` | No       | Bootstrap admin password (default: `Admin123`) |
 | `SPP_CA_FILE`        | No       | TLS CA bundle path (uses system CA store if unset) |
 
-All 21 tests skip automatically when `SPP_HOST` is not set.
+Integration tests (21) skip automatically when `SPP_HOST` is not set.
+Unit tests (32) always run regardless of environment.
 
-**CI limitation**: These tests cannot run in CI/CD pipelines because they
-require a live SPP appliance. The pipeline's PR validation stage only builds
-the artifacts (collection tarball and wheel) to verify packaging. Behavioral
-correctness must be validated manually against a test appliance before release.
+**CI usage**: Unit tests can run in any CI pipeline. Integration tests
+require a live SPP appliance and are skipped in CI unless `SPP_HOST` is
+configured. The pipeline's PR validation stage runs unit tests and builds
+the artifacts (collection tarball and wheel) to verify packaging.
 
-**What the tests do**:
+**What the integration tests do**:
 
 1. Create a fully-privileged test admin using the bootstrap admin (PKCE auth)
 2. Provision test objects (asset, accounts, cert user, A2A registration, access
@@ -191,7 +209,7 @@ correctness must be validated manually against a test appliance before release.
 5. Verify credentials are retrieved correctly (including value-match checks)
 6. Clean up all provisioned objects in reverse order
 
-**Test coverage** (21 tests):
+**Integration test coverage** (21 tests):
 
 - **A2A plugin** (8 tests): password retrieval, password value correctness,
   private key retrieval, multi-key retrieval, invalid API key, missing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,14 @@ safeguard-ansible/
     ├── pyproject.toml                   # PyPI packaging (safeguardcredentialtype)
     ├── README.md                        # Installation & configuration docs
     ├── Images/                          # Screenshots for docs
-    ├── tests/                           # Manual test steps & playbooks
-    │   ├── steps.txt
-    │   └── playbook.yaml
+    ├── tests/                           # Automated + manual tests
+    │   ├── pytest.ini                   # Pytest config & markers
+    │   ├── requirements.txt             # Test dependencies
+    │   ├── conftest.py                  # Session fixtures, A2A provisioning, auto-skip
+    │   ├── test_unit.py                 # Unit tests (15 tests, no appliance needed)
+    │   ├── test_integration.py          # Integration tests (4 tests, need SPP_HOST)
+    │   ├── steps.txt                    # Manual AWX deployment test steps
+    │   └── playbook.yaml                # Manual test playbook
     └── safeguardcredentialtype/
         └── __init__.py                  # AWX credential plugin implementation
 ```
@@ -202,6 +207,37 @@ correctness must be validated manually against a test appliance before release.
 
 Follow the step-by-step instructions in `credential_type_plugin/tests/steps.txt`
 for AWX/AAP deployment and verification.
+
+### Automated tests (credential type plugin)
+
+The credential type plugin has both unit tests and integration tests in
+`credential_type_plugin/tests/`.
+
+**Unit tests** (15 tests) — always run, no appliance needed:
+
+```bash
+cd credential_type_plugin
+python3 -m pytest tests/test_unit.py -v
+```
+
+**Integration tests** (4 tests) — require a live SPP appliance:
+
+```bash
+cd credential_type_plugin
+SPP_HOST=<appliance-ip> SPP_ADMIN_PASSWORD=<admin-pw> python3 -m pytest tests/test_integration.py -v
+```
+
+These tests self-provision all needed objects (admin user, asset, account,
+client certificate, A2A registration) using the bootstrap admin account and
+clean up afterward. The bootstrap admin (`Admin` user with the password
+specified by `SPP_ADMIN_PASSWORD`) must exist and have permission to create
+users. This is the same factory-default admin used by the collection tests.
+
+| Variable             | Required | Description |
+|----------------------|----------|-------------|
+| `SPP_HOST`           | Yes      | Appliance IP or hostname |
+| `SPP_ADMIN_PASSWORD` | No       | Bootstrap admin password (default: `Admin123`) |
+| `SPP_CA_FILE`        | No       | TLS CA bundle path (disables TLS verification if unset) |
 
 ## PySafeguard API usage
 

--- a/collection/oneidentity/safeguard/galaxy.yml
+++ b/collection/oneidentity/safeguard/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: oneidentity
 name: safeguardcollection
-version: 2.0.0
+version: 2.0.1
 readme: README.md
 authors:
   - "One Identity LLC <support@oneidentity.com>"

--- a/collection/tests/test_unit.py
+++ b/collection/tests/test_unit.py
@@ -1,0 +1,404 @@
+# Copyright (c) One Identity LLC.
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+
+"""Unit tests for the collection lookup plugins.
+
+These tests do NOT require a live SPP appliance or Ansible. They verify
+the pure-logic helper functions and input validation in isolation.
+"""
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add the plugins directory to the path so we can import directly
+PLUGINS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "oneidentity", "safeguard", "plugins", "lookup"
+)
+sys.path.insert(0, os.path.abspath(PLUGINS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# safeguardcredentials — _resolve_verify
+# ---------------------------------------------------------------------------
+
+class TestCredentialsResolveVerify:
+    """Test _resolve_verify in safeguardcredentials plugin."""
+
+    def test_path_string_returns_path(self):
+        from safeguardcredentials import _resolve_verify
+
+        assert _resolve_verify("/path/to/ca.pem") == "/path/to/ca.pem"
+
+    def test_empty_string_with_validate_true_returns_true(self):
+        from safeguardcredentials import _resolve_verify
+
+        assert _resolve_verify("", validate_certs=True) is True
+
+    def test_none_with_validate_true_returns_true(self):
+        from safeguardcredentials import _resolve_verify
+
+        assert _resolve_verify(None, validate_certs=True) is True
+
+    def test_none_with_validate_false_returns_false(self):
+        from safeguardcredentials import _resolve_verify
+
+        assert _resolve_verify(None, validate_certs=False) is False
+
+    def test_path_overrides_validate_false(self):
+        from safeguardcredentials import _resolve_verify
+
+        assert _resolve_verify("/ca.pem", validate_certs=False) == "/ca.pem"
+
+    def test_false_with_validate_false_returns_false(self):
+        from safeguardcredentials import _resolve_verify
+
+        assert _resolve_verify(False, validate_certs=False) is False
+
+
+# ---------------------------------------------------------------------------
+# safeguardaccessrequest — _resolve_verify
+# ---------------------------------------------------------------------------
+
+class TestAccessRequestResolveVerify:
+    """Test _resolve_verify in safeguardaccessrequest plugin."""
+
+    def test_path_string_returns_path(self):
+        from safeguardaccessrequest import _resolve_verify
+
+        assert _resolve_verify("/path/to/ca.pem") == "/path/to/ca.pem"
+
+    def test_none_with_validate_true_returns_true(self):
+        from safeguardaccessrequest import _resolve_verify
+
+        assert _resolve_verify(None, validate_certs=True) is True
+
+    def test_none_with_validate_false_returns_false(self):
+        from safeguardaccessrequest import _resolve_verify
+
+        assert _resolve_verify(None, validate_certs=False) is False
+
+    def test_path_overrides_validate_false(self):
+        from safeguardaccessrequest import _resolve_verify
+
+        assert _resolve_verify("/ca.pem", validate_certs=False) == "/ca.pem"
+
+
+# ---------------------------------------------------------------------------
+# safeguardaccessrequest — _find_entitlement
+# ---------------------------------------------------------------------------
+
+class TestFindEntitlement:
+    """Test _find_entitlement logic with mocked client."""
+
+    def _mock_client_with_entitlements(self, entitlements):
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = entitlements
+        client.get.return_value = resp
+        return client
+
+    def test_matches_by_asset_name(self):
+        from safeguardaccessrequest import _find_entitlement
+
+        client = self._mock_client_with_entitlements([
+            {"Account": {"Id": 1, "AssetId": 10, "AssetName": "myserver",
+                         "AssetNetworkAddress": "10.0.0.1", "Name": "root"}},
+        ])
+        result = _find_entitlement(client, "myserver", "password")
+        assert result == {"AccountId": 1, "AssetId": 10}
+
+    def test_matches_by_network_address(self):
+        from safeguardaccessrequest import _find_entitlement
+
+        client = self._mock_client_with_entitlements([
+            {"Account": {"Id": 2, "AssetId": 20, "AssetName": "dbserver",
+                         "AssetNetworkAddress": "10.0.0.5", "Name": "admin"}},
+        ])
+        result = _find_entitlement(client, "10.0.0.5", "password")
+        assert result == {"AccountId": 2, "AssetId": 20}
+
+    def test_case_insensitive_match(self):
+        from safeguardaccessrequest import _find_entitlement
+
+        client = self._mock_client_with_entitlements([
+            {"Account": {"Id": 3, "AssetId": 30, "AssetName": "MyServer",
+                         "AssetNetworkAddress": "10.0.0.2", "Name": "user1"}},
+        ])
+        result = _find_entitlement(client, "myserver", "password")
+        assert result == {"AccountId": 3, "AssetId": 30}
+
+    def test_filters_by_account_name(self):
+        from safeguardaccessrequest import _find_entitlement
+
+        client = self._mock_client_with_entitlements([
+            {"Account": {"Id": 1, "AssetId": 10, "AssetName": "server",
+                         "AssetNetworkAddress": "10.0.0.1", "Name": "root"}},
+            {"Account": {"Id": 2, "AssetId": 10, "AssetName": "server",
+                         "AssetNetworkAddress": "10.0.0.1", "Name": "admin"}},
+        ])
+        result = _find_entitlement(client, "server", "password", account_name="admin")
+        assert result == {"AccountId": 2, "AssetId": 10}
+
+    def test_raises_when_no_match(self):
+        from ansible.errors import AnsibleError
+        from safeguardaccessrequest import _find_entitlement
+
+        client = self._mock_client_with_entitlements([
+            {"Account": {"Id": 1, "AssetId": 10, "AssetName": "other",
+                         "AssetNetworkAddress": "10.0.0.9", "Name": "root"}},
+        ])
+        with pytest.raises(AnsibleError, match="not found in entitlements"):
+            _find_entitlement(client, "myserver", "password")
+
+    def test_raises_when_account_not_found(self):
+        from ansible.errors import AnsibleError
+        from safeguardaccessrequest import _find_entitlement
+
+        client = self._mock_client_with_entitlements([
+            {"Account": {"Id": 1, "AssetId": 10, "AssetName": "server",
+                         "AssetNetworkAddress": "10.0.0.1", "Name": "root"}},
+        ])
+        with pytest.raises(AnsibleError, match="No entitlement found for account"):
+            _find_entitlement(client, "server", "password", account_name="nobody")
+
+    def test_raises_on_multiple_matches(self):
+        from ansible.errors import AnsibleError
+        from safeguardaccessrequest import _find_entitlement
+
+        client = self._mock_client_with_entitlements([
+            {"Account": {"Id": 1, "AssetId": 10, "AssetName": "server",
+                         "AssetNetworkAddress": "10.0.0.1", "Name": "root"}},
+            {"Account": {"Id": 2, "AssetId": 10, "AssetName": "server",
+                         "AssetNetworkAddress": "10.0.0.1", "Name": "admin"}},
+        ])
+        with pytest.raises(AnsibleError, match="Multiple entitlements"):
+            _find_entitlement(client, "server", "password")
+
+    def test_raises_on_api_error(self):
+        from ansible.errors import AnsibleError
+        from safeguardaccessrequest import _find_entitlement
+
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 403
+        resp.text = "Forbidden"
+        client.get.return_value = resp
+
+        with pytest.raises(AnsibleError, match="Error obtaining entitlements"):
+            _find_entitlement(client, "server", "password")
+
+
+# ---------------------------------------------------------------------------
+# safeguardaccessrequest — _find_existing_request
+# ---------------------------------------------------------------------------
+
+class TestFindExistingRequest:
+    """Test _find_existing_request logic."""
+
+    def test_finds_active_request(self):
+        from safeguardaccessrequest import _find_existing_request
+
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [
+            {"Id": "req-123", "State": "RequestAvailable", "WasExpired": False},
+        ]
+        client.get.return_value = resp
+
+        result = _find_existing_request(client, 1, 10, "Password")
+        assert result == "req-123"
+
+    def test_skips_expired_request(self):
+        from safeguardaccessrequest import _find_existing_request
+
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [
+            {"Id": "req-old", "State": "RequestAvailable", "WasExpired": True},
+        ]
+        client.get.return_value = resp
+
+        result = _find_existing_request(client, 1, 10, "Password")
+        assert result is None
+
+    def test_returns_none_on_api_error(self):
+        from safeguardaccessrequest import _find_existing_request
+
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 500
+        client.get.return_value = resp
+
+        result = _find_existing_request(client, 1, 10, "Password")
+        assert result is None
+
+    def test_returns_none_when_no_requests(self):
+        from safeguardaccessrequest import _find_existing_request
+
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = []
+        client.get.return_value = resp
+
+        result = _find_existing_request(client, 1, 10, "Password")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# safeguardaccessrequest — _checkout_with_retry
+# ---------------------------------------------------------------------------
+
+class TestCheckoutWithRetry:
+    """Test _checkout_with_retry logic."""
+
+    def test_returns_on_first_success(self):
+        from safeguardaccessrequest import _checkout_with_retry
+
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = "MyPassword123"
+        client.post.return_value = resp
+
+        result = _checkout_with_retry(client, "req-1", "password", timeout=10)
+        assert result == "MyPassword123"
+        assert client.post.call_count == 1
+
+    def test_retries_on_failure_then_succeeds(self):
+        from safeguardaccessrequest import _checkout_with_retry
+
+        client = MagicMock()
+        fail_resp = MagicMock()
+        fail_resp.status_code = 409
+        fail_resp.text = "Not ready"
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        success_resp.json.return_value = "GotIt"
+        client.post.side_effect = [fail_resp, success_resp]
+
+        result = _checkout_with_retry(client, "req-1", "password", timeout=30)
+        assert result == "GotIt"
+
+    def test_raises_after_timeout(self):
+        from ansible.errors import AnsibleError
+        from safeguardaccessrequest import _checkout_with_retry
+
+        client = MagicMock()
+        fail_resp = MagicMock()
+        fail_resp.status_code = 409
+        fail_resp.text = "Not ready"
+        client.post.return_value = fail_resp
+
+        with pytest.raises(AnsibleError, match="Error checking out credential"):
+            _checkout_with_retry(client, "req-1", "password", timeout=0)
+
+
+# ---------------------------------------------------------------------------
+# safeguardaccessrequest — _create_or_reuse_request
+# ---------------------------------------------------------------------------
+
+class TestCreateOrReuseRequest:
+    """Test _create_or_reuse_request logic."""
+
+    def test_returns_new_request_id_on_201(self):
+        from safeguardaccessrequest import _create_or_reuse_request
+
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.json.return_value = {"Id": "new-req-id"}
+        client.post.return_value = resp
+
+        result = _create_or_reuse_request(client, 1, 10, "myasset", "password")
+        assert result == "new-req-id"
+
+    def test_reuses_existing_on_error_90001(self):
+        from safeguardaccessrequest import _create_or_reuse_request
+
+        client = MagicMock()
+        # First call: POST to create request fails with 90001
+        create_resp = MagicMock()
+        create_resp.status_code = 400
+        create_resp.json.return_value = {"Code": "90001", "Message": "Already exists"}
+        create_resp.text = '{"Code": "90001"}'
+        # Second call: GET to find existing
+        get_resp = MagicMock()
+        get_resp.status_code = 200
+        get_resp.json.return_value = [
+            {"Id": "existing-id", "State": "RequestAvailable", "WasExpired": False}
+        ]
+        client.post.return_value = create_resp
+        client.get.return_value = get_resp
+
+        result = _create_or_reuse_request(client, 1, 10, "myasset", "password")
+        assert result == "existing-id"
+
+    def test_raises_on_other_error(self):
+        from ansible.errors import AnsibleError
+        from safeguardaccessrequest import _create_or_reuse_request
+
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 403
+        resp.text = "Forbidden"
+        resp.json.return_value = {"Code": "60108", "Message": "Forbidden"}
+        client.post.return_value = resp
+
+        with pytest.raises(AnsibleError, match="Error creating access request"):
+            _create_or_reuse_request(client, 1, 10, "myasset", "password")
+
+
+# ---------------------------------------------------------------------------
+# safeguardcredentials — validate_certs normalization
+# ---------------------------------------------------------------------------
+
+class TestCredentialsValidateCertsNormalization:
+    """Test that validate_certs string values are properly normalized.
+
+    This tests the logic inline in the LookupModule.run method by verifying
+    _resolve_verify handles the normalized boolean values correctly.
+    """
+
+    def test_string_false_normalizes(self):
+        """'false' string should map to validate_certs=False."""
+        from safeguardcredentials import _resolve_verify
+
+        val = "false"
+        normalized = val.lower() not in ('false', '0', 'no')
+        assert normalized is False
+        assert _resolve_verify(None, validate_certs=normalized) is False
+
+    def test_string_true_normalizes(self):
+        """'true' string should map to validate_certs=True."""
+        from safeguardcredentials import _resolve_verify
+
+        val = "true"
+        normalized = val.lower() not in ('false', '0', 'no')
+        assert normalized is True
+        assert _resolve_verify(None, validate_certs=normalized) is True
+
+    def test_string_zero_normalizes(self):
+        """'0' string should map to validate_certs=False."""
+        from safeguardcredentials import _resolve_verify
+
+        val = "0"
+        normalized = val.lower() not in ('false', '0', 'no')
+        assert normalized is False
+        assert _resolve_verify(None, validate_certs=normalized) is False
+
+    def test_string_no_normalizes(self):
+        """'no' string should map to validate_certs=False."""
+        from safeguardcredentials import _resolve_verify
+
+        val = "no"
+        normalized = val.lower() not in ('false', '0', 'no')
+        assert normalized is False
+        assert _resolve_verify(None, validate_certs=normalized) is False

--- a/credential_type_plugin/README.md
+++ b/credential_type_plugin/README.md
@@ -25,3 +25,15 @@ The installation of the Safeguard Credential Type plugin must be done on the ser
 > sudo awx-manage setup_managed_credential_types
 > sudo automation-controller-service restart
 ```
+
+## Upgrading AWX / Ansible Automation Platform
+
+After upgrading AWX or Ansible Automation Platform, the Python virtual environment may be recreated. If this happens, the Safeguard Credential Type plugin and its dependencies must be reinstalled:
+
+```text
+> sudo awx-python -m pip install safeguardcredentialtype
+> sudo awx-manage setup_managed_credential_types
+> sudo automation-controller-service restart
+```
+
+If you see `KeyError: 'spp_plugin'` in the AWX logs after an upgrade, this indicates the plugin is not installed in the current Python environment. Running the commands above will resolve the issue.

--- a/credential_type_plugin/pyproject.toml
+++ b/credential_type_plugin/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "safeguardcredentialtype"
-version = "2.0.0"
+version = "2.0.1"
 description = "One Identity Safeguard Credential Type plugin for Ansible"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "Apache-2.0"

--- a/credential_type_plugin/safeguardcredentialtype/__init__.py
+++ b/credential_type_plugin/safeguardcredentialtype/__init__.py
@@ -4,8 +4,6 @@
 
 import collections
 
-from pysafeguard import A2AContext, A2AType
-
 CredentialPlugin = collections.namedtuple('CredentialPlugin', ['name', 'inputs', 'backend'])
 
 
@@ -34,6 +32,14 @@ def _get_spp_credential(**kwargs):
     :arg spp_credential_type: Credential type (password or privatekey)
     :returns: a text string containing the credential
     """
+    try:
+        from pysafeguard import A2AContext, A2AType
+    except ImportError as e:
+        raise ValueError(
+            'The pysafeguard package is not installed. '
+            'Install it with: pip install pysafeguard'
+        ) from e
+
     api_key = kwargs.get('spp_api_key', None)
     appliance = kwargs.get('spp_appliance', None)
     cert = kwargs.get('spp_certificate_path', None)

--- a/credential_type_plugin/tests/conftest.py
+++ b/credential_type_plugin/tests/conftest.py
@@ -16,6 +16,9 @@ import sys
 
 import pytest
 
+# Make the credential plugin package importable regardless of cwd
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 # Make collection test helpers importable
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "collection", "tests"))
 

--- a/credential_type_plugin/tests/conftest.py
+++ b/credential_type_plugin/tests/conftest.py
@@ -1,0 +1,169 @@
+# Copyright (c) One Identity LLC.
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+
+"""Shared fixtures for credential type plugin tests.
+
+Environment variables:
+    SPP_HOST            Appliance address (required — integration tests skip if unset)
+    SPP_ADMIN_PASSWORD  Bootstrap admin password (default: Admin123)
+    SPP_CA_FILE         TLS CA bundle path (optional; disables TLS verification if unset)
+"""
+
+import logging
+import os
+import sys
+
+import pytest
+
+# Make collection test helpers importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "collection", "tests"))
+
+log = logging.getLogger("sgans_credplugin_tests")
+
+
+# ---------------------------------------------------------------------------
+# Auto-skip when SPP_HOST is not set
+# ---------------------------------------------------------------------------
+
+def pytest_collection_modifyitems(config, items):
+    if not os.environ.get("SPP_HOST"):
+        skip = pytest.mark.skip(reason="SPP_HOST not set — skipping integration tests")
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip)
+
+
+# ---------------------------------------------------------------------------
+# Environment fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def spp_host():
+    return os.environ["SPP_HOST"]
+
+
+@pytest.fixture(scope="session")
+def spp_admin_password():
+    return os.environ.get("SPP_ADMIN_PASSWORD", "Admin123")
+
+
+@pytest.fixture(scope="session")
+def spp_verify():
+    ca = os.environ.get("SPP_CA_FILE")
+    return ca if ca else False
+
+
+# ---------------------------------------------------------------------------
+# Admin client
+# ---------------------------------------------------------------------------
+
+ALL_ADMIN_ROLES = [
+    "GlobalAdmin", "AssetAdmin", "PolicyAdmin", "UserAdmin",
+    "ApplianceAdmin", "HelpdeskAdmin", "OperationsAdmin",
+    "Auditor", "ApplicationAuditor", "SystemAuditor",
+]
+
+TEST_ADMIN_PASSWORD = "SgAns_Adm1n_P@ss9"
+
+
+@pytest.fixture(scope="session")
+def admin_client(spp_host, spp_admin_password, spp_verify):
+    """Create a fully-privileged test admin and return a logged-in client."""
+    from pysafeguard import SafeguardClient, PkceAuth
+    from helpers.provisioning import create_local_user, set_user_password, delete_user
+
+    bootstrap = SafeguardClient(
+        spp_host, auth=PkceAuth("local", "Admin", spp_admin_password), verify=spp_verify
+    )
+    bootstrap.login()
+
+    user = create_local_user(bootstrap, label="CredPlugAdmin", admin_roles=ALL_ADMIN_ROLES)
+    user_id = user["Id"]
+    set_user_password(bootstrap, user_id, TEST_ADMIN_PASSWORD)
+    bootstrap.logout()
+
+    client = SafeguardClient(
+        spp_host,
+        auth=PkceAuth("local", user["Name"], TEST_ADMIN_PASSWORD),
+        verify=spp_verify,
+    )
+    try:
+        client.login()
+        yield client
+        client.logout()
+    finally:
+        bootstrap2 = SafeguardClient(
+            spp_host, auth=PkceAuth("local", "Admin", spp_admin_password), verify=spp_verify
+        )
+        bootstrap2.login()
+        delete_user(bootstrap2, user_id)
+        bootstrap2.logout()
+
+
+# ---------------------------------------------------------------------------
+# A2A setup: cert, cert user, asset, account, registration, API key
+# ---------------------------------------------------------------------------
+
+KNOWN_PASSWORD = "SgAns_CredPlug_P@ss42!"
+
+
+@pytest.fixture(scope="session")
+def a2a_setup(admin_client, spp_verify, tmp_path_factory):
+    """Provision a full A2A chain and yield connection details for tests."""
+    from helpers.certificates import generate_client_cert, read_cert_base64
+    from helpers.provisioning import (
+        create_asset, create_account, set_account_password,
+        create_cert_user, create_a2a_registration, add_retrievable_account,
+        upload_trusted_cert,
+        delete_asset, delete_account, delete_user,
+        delete_a2a_registration, delete_trusted_cert,
+    )
+
+    tmpdir = str(tmp_path_factory.mktemp("credplugin_cert"))
+    cert_path, key_path, thumbprint = generate_client_cert(tmpdir)
+    cert_b64 = read_cert_base64(cert_path)
+
+    # Track for cleanup
+    created_cert = False
+    cert_user = None
+    asset = None
+    account = None
+    a2a_reg = None
+
+    try:
+        upload_trusted_cert(admin_client, cert_b64)
+        created_cert = True
+        cert_user = create_cert_user(admin_client, thumbprint, label="CredPlugCert")
+        asset = create_asset(admin_client, label="CredPlugAsset")
+        account = create_account(admin_client, asset["Id"], label="CredPlugAcct")
+        set_account_password(admin_client, account["Id"], KNOWN_PASSWORD)
+        a2a_reg = create_a2a_registration(admin_client, cert_user["Id"], label="CredPlugA2A")
+        ra = add_retrievable_account(admin_client, a2a_reg["Id"], account["Id"])
+    except Exception:
+        # Best-effort cleanup on partial failure
+        if a2a_reg:
+            delete_a2a_registration(admin_client, a2a_reg["Id"])
+        if account:
+            delete_account(admin_client, account["Id"])
+        if asset:
+            delete_asset(admin_client, asset["Id"])
+        if cert_user:
+            delete_user(admin_client, cert_user["Id"])
+        if created_cert:
+            delete_trusted_cert(admin_client, thumbprint)
+        raise
+
+    yield {
+        "api_key": ra["ApiKey"],
+        "cert_path": cert_path,
+        "key_path": key_path,
+        "known_password": KNOWN_PASSWORD,
+    }
+
+    # Cleanup
+    delete_a2a_registration(admin_client, a2a_reg["Id"])
+    delete_account(admin_client, account["Id"])
+    delete_asset(admin_client, asset["Id"])
+    delete_user(admin_client, cert_user["Id"])
+    delete_trusted_cert(admin_client, thumbprint)

--- a/credential_type_plugin/tests/pytest.ini
+++ b/credential_type_plugin/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: tests requiring a live SPP appliance with A2A configured (set SPP_HOST to enable)

--- a/credential_type_plugin/tests/requirements.txt
+++ b/credential_type_plugin/tests/requirements.txt
@@ -1,0 +1,2 @@
+pysafeguard>=8,<9
+pytest

--- a/credential_type_plugin/tests/test_integration.py
+++ b/credential_type_plugin/tests/test_integration.py
@@ -1,0 +1,87 @@
+# Copyright (c) One Identity LLC.
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+
+"""Integration tests for the credential type plugin.
+
+These tests require a live SPP appliance. They self-provision all needed
+objects (asset, account, A2A registration, client cert) and clean up
+afterward. Set the following environment variables:
+
+    SPP_HOST            Appliance address (required)
+    SPP_ADMIN_PASSWORD  Bootstrap admin password (default: Admin123)
+    SPP_CA_FILE         TLS CA bundle path (optional)
+
+All tests are marked with @pytest.mark.integration and will be skipped
+when SPP_HOST is not set.
+"""
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+class TestPasswordRetrieval:
+    """Test password retrieval via the plugin backend."""
+
+    def test_retrieve_password(self, spp_host, spp_verify, a2a_setup):
+        from safeguardcredentialtype import _get_spp_credential
+
+        result = _get_spp_credential(
+            spp_api_key=a2a_setup["api_key"],
+            spp_appliance=spp_host,
+            spp_certificate_path=a2a_setup["cert_path"],
+            spp_key_path=a2a_setup["key_path"],
+            spp_tls_path=spp_verify if spp_verify else None,
+            spp_validate_certs=bool(spp_verify),
+            spp_credential_type="password",
+        )
+        assert result is not None
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_retrieve_known_password(self, spp_host, spp_verify, a2a_setup):
+        from safeguardcredentialtype import _get_spp_credential
+
+        result = _get_spp_credential(
+            spp_api_key=a2a_setup["api_key"],
+            spp_appliance=spp_host,
+            spp_certificate_path=a2a_setup["cert_path"],
+            spp_key_path=a2a_setup["key_path"],
+            spp_tls_path=spp_verify if spp_verify else None,
+            spp_validate_certs=bool(spp_verify),
+            spp_credential_type="password",
+        )
+        assert result == a2a_setup["known_password"]
+
+
+class TestErrorHandling:
+    """Test error handling with invalid inputs against a live appliance."""
+
+    def test_invalid_api_key(self, spp_host, spp_verify, a2a_setup):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Failed to retrieve"):
+            _get_spp_credential(
+                spp_api_key="00000000-0000-0000-0000-000000000000",
+                spp_appliance=spp_host,
+                spp_certificate_path=a2a_setup["cert_path"],
+                spp_key_path=a2a_setup["key_path"],
+                spp_tls_path=spp_verify if spp_verify else None,
+                spp_validate_certs=bool(spp_verify),
+                spp_credential_type="password",
+            )
+
+    def test_unreachable_appliance(self, a2a_setup):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Failed to retrieve"):
+            _get_spp_credential(
+                spp_api_key=a2a_setup["api_key"],
+                spp_appliance="192.0.2.1",
+                spp_certificate_path=a2a_setup["cert_path"],
+                spp_key_path=a2a_setup["key_path"],
+                spp_validate_certs="false",
+                spp_credential_type="password",
+            )

--- a/credential_type_plugin/tests/test_unit.py
+++ b/credential_type_plugin/tests/test_unit.py
@@ -1,0 +1,184 @@
+# Copyright (c) One Identity LLC.
+# Licensed under the Apache License, Version 2.0.
+# See LICENSE file in the project root for full license information.
+
+"""Unit tests for the credential type plugin.
+
+These tests do NOT require a live SPP appliance or pysafeguard to be
+exercising the import path. They verify the plugin's defensive behavior.
+"""
+
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+class TestLazyImport:
+    """Verify that the plugin module loads without pysafeguard (issue #3)."""
+
+    def test_module_loads_without_pysafeguard(self):
+        """The entry point module must import even if pysafeguard is absent."""
+        # Temporarily hide pysafeguard from the import system
+        with patch.dict(sys.modules, {"pysafeguard": None}):
+            # Force a fresh import of the plugin module
+            if "safeguardcredentialtype" in sys.modules:
+                mod = importlib.reload(
+                    sys.modules["safeguardcredentialtype"]
+                )
+            else:
+                mod = importlib.import_module("safeguardcredentialtype")
+
+            # The CredentialPlugin namedtuple must be accessible
+            assert mod.spp_plugin is not None
+            assert mod.spp_plugin.name == "Safeguard Credential"
+
+    def test_backend_raises_clear_error_when_pysafeguard_missing(self):
+        """Calling the backend without pysafeguard gives a helpful message."""
+        from safeguardcredentialtype import _get_spp_credential
+
+        with patch.dict(sys.modules, {"pysafeguard": None}):
+            # Also need to make the import inside the function fail
+            original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+            def mock_import(name, *args, **kwargs):
+                if name == "pysafeguard":
+                    raise ImportError("No module named 'pysafeguard'")
+                return original_import(name, *args, **kwargs)
+
+            with patch("builtins.__import__", side_effect=mock_import):
+                with pytest.raises(ValueError, match="pysafeguard.*not installed"):
+                    _get_spp_credential(
+                        spp_api_key="fake-key",
+                        spp_appliance="10.0.0.1",
+                        spp_certificate_path="/tmp/cert.pem",
+                        spp_key_path="/tmp/key.pem",
+                    )
+
+
+class TestResolveVerify:
+    """Test the _resolve_verify helper."""
+
+    def test_path_string_returns_path(self):
+        from safeguardcredentialtype import _resolve_verify
+
+        assert _resolve_verify("/path/to/ca.pem") == "/path/to/ca.pem"
+
+    def test_empty_string_with_validate_true_returns_true(self):
+        from safeguardcredentialtype import _resolve_verify
+
+        assert _resolve_verify("", validate_certs=True) is True
+
+    def test_none_with_validate_true_returns_true(self):
+        from safeguardcredentialtype import _resolve_verify
+
+        assert _resolve_verify(None, validate_certs=True) is True
+
+    def test_none_with_validate_false_returns_false(self):
+        from safeguardcredentialtype import _resolve_verify
+
+        assert _resolve_verify(None, validate_certs=False) is False
+
+    def test_path_overrides_validate_false(self):
+        from safeguardcredentialtype import _resolve_verify
+
+        # If a CA path is given, it takes precedence over validate_certs=False
+        assert _resolve_verify("/path/to/ca.pem", validate_certs=False) == "/path/to/ca.pem"
+
+
+class TestInputValidation:
+    """Test input validation in the backend function."""
+
+    def test_missing_api_key(self):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Missing credential API key"):
+            _get_spp_credential(
+                spp_appliance="10.0.0.1",
+                spp_certificate_path="/tmp/cert.pem",
+                spp_key_path="/tmp/key.pem",
+            )
+
+    def test_missing_appliance(self):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Missing appliance"):
+            _get_spp_credential(
+                spp_api_key="fake-key",
+                spp_certificate_path="/tmp/cert.pem",
+                spp_key_path="/tmp/key.pem",
+            )
+
+    def test_missing_certificate(self):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Missing client authentication certificate"):
+            _get_spp_credential(
+                spp_api_key="fake-key",
+                spp_appliance="10.0.0.1",
+                spp_key_path="/tmp/key.pem",
+            )
+
+    def test_missing_key(self):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Missing client authentication key"):
+            _get_spp_credential(
+                spp_api_key="fake-key",
+                spp_appliance="10.0.0.1",
+                spp_certificate_path="/tmp/cert.pem",
+            )
+
+    def test_invalid_credential_type(self):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Invalid credential type"):
+            _get_spp_credential(
+                spp_api_key="fake-key",
+                spp_appliance="10.0.0.1",
+                spp_certificate_path="/tmp/cert.pem",
+                spp_key_path="/tmp/key.pem",
+                spp_credential_type="invalid",
+            )
+
+
+class TestValidateCertsNormalization:
+    """Test string-to-bool normalization for validate_certs."""
+
+    def test_string_false(self):
+        from safeguardcredentialtype import _get_spp_credential
+
+        # Should not raise about validate_certs — will fail on network instead
+        with pytest.raises(ValueError, match="Failed to retrieve"):
+            _get_spp_credential(
+                spp_api_key="fake-key",
+                spp_appliance="192.0.2.1",
+                spp_certificate_path="/tmp/cert.pem",
+                spp_key_path="/tmp/key.pem",
+                spp_validate_certs="false",
+            )
+
+    def test_string_zero(self):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Failed to retrieve"):
+            _get_spp_credential(
+                spp_api_key="fake-key",
+                spp_appliance="192.0.2.1",
+                spp_certificate_path="/tmp/cert.pem",
+                spp_key_path="/tmp/key.pem",
+                spp_validate_certs="0",
+            )
+
+    def test_string_true(self):
+        from safeguardcredentialtype import _get_spp_credential
+
+        with pytest.raises(ValueError, match="Failed to retrieve"):
+            _get_spp_credential(
+                spp_api_key="fake-key",
+                spp_appliance="192.0.2.1",
+                spp_certificate_path="/tmp/cert.pem",
+                spp_key_path="/tmp/key.pem",
+                spp_validate_certs="true",
+            )


### PR DESCRIPTION
# Summary

Fixes #3 — After an AWX upgrade, the credential type plugin could crash the entire credential types API with
KeyError: 'spp_plugin' if pysafeguard was missing from the rebuilt venv.

# Changes

Bug fix

 - Moved the pysafeguard import from module top-level to inside the backend function (lazy-load pattern). This
ensures AWX can always discover and register the entry point, even when the dependency is missing. Users get a
clear error only when actually invoking credential retrieval.
 - Documented post-upgrade reinstallation steps in the credential plugin README.

Test coverage

 - Credential type plugin: 15 unit tests (lazy import, input validation, TLS option mapping, string normalization)
 + 4 self-provisioning integration tests against a live appliance.
 - Collection lookup plugins: 32 unit tests covering _resolve_verify, _find_entitlement, _find_existing_request,
_checkout_with_retry, _create_or_reuse_request, and validate_certs normalization.
 - All integration tests are conditional on SPP_HOST — unit tests always run and are CI-ready