### PR TITLE
chore: add .worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Worktrees
+.worktrees/


### PR DESCRIPTION
Add `.worktrees/` directory to `.gitignore` to support git worktree-based development workflows.

This prevents worktree directories from being accidentally committed to the repository.