### PR TITLE
Add CODEOWNERS for SafeguardPasswords team review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require review from SafeguardPasswords team for all changes
+* @OneIdentity/SafeguardPasswords


### PR DESCRIPTION
Adds .github/CODEOWNERS requiring review from SafeguardPasswords team for all changes.