### PR TITLE
Skills harmonization: add architecture skill

### DIFF
--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: architecture
+description: >-
+  Use when understanding safeguard-ansible's repository layout, Ansible entry
+  points, authentication flows, and the boundary between the collection,
+  credential type plugin, and PySafeguard.
+---
+# safeguard-ansible Architecture
+This repository contains two distributable integrations for One Identity
+Safeguard for Privileged Passwords (SPP):
+- an **Ansible Galaxy collection** in `collection/oneidentity/safeguard/`
+- an **AWX / AAP managed credential plugin** in `credential_type_plugin/`
+Both are thin adapters over `pysafeguard>=8,<9`; the repo does not implement its
+own Safeguard REST client.
+## Directory map
+```
+safeguard-ansible/
+├── collection/
+│   ├── oneidentity/safeguard/
+│   │   ├── galaxy.yml
+│   │   ├── meta/runtime.yml
+│   │   └── plugins/lookup/
+│   │       ├── safeguardcredentials.py
+│   │       └── safeguardaccessrequest.py
+│   └── tests/
+│       ├── conftest.py
+│       ├── helpers/
+│       └── playbooks/
+├── credential_type_plugin/
+│   ├── pyproject.toml
+│   ├── safeguardcredentialtype/__init__.py
+│   └── tests/
+├── pipeline-templates/
+└── versionnumber.ps1
+```
+## 1. Entry point / public API surface
+### Collection entry points
+The collection publishes namespace `oneidentity.safeguardcollection` from
+`collection/oneidentity/safeguard/galaxy.yml`.
+Public Ansible-facing entry points:
+- `lookup('oneidentity.safeguardcollection.safeguardcredentials', ...)`
+- `lookup('oneidentity.safeguardcollection.safeguardaccessrequest', ...)`
+Both files live under `plugins/lookup/` and implement Ansible's
+`LookupBase.run(self, terms, variables=None, **kwargs)` contract. They are meant
+for playbooks, variables, templates, and inventory lookups.
+Collection contract details:
+- `DOCUMENTATION`, `EXAMPLES`, and `RETURN` are part of the public surface.
+- Returned values are plain strings, not reusable session objects.
+- The repo currently ships **no** modules under `plugins/modules`; this is a
+  lookup-only collection.
+### AWX / AAP credential plugin entry point
+The second component is the Python package `safeguardcredentialtype`, defined in
+`credential_type_plugin/pyproject.toml`.
+Its AWX discovery point is:
+```toml
+[project.entry-points."awx.credential_plugins"]
+spp_plugin = "safeguardcredentialtype:spp_plugin"
+```
+`credential_type_plugin/safeguardcredentialtype/__init__.py` exports:
+- `CredentialPlugin` namedtuple
+- `spp_plugin`
+- `_get_spp_credential()` backend
+- `_resolve_verify()` TLS helper
+AWX reads `spp_plugin.inputs` to render the UI and calls `backend` when it needs
+a runtime credential value.
+### Collection vs credential type packaging
+| Component | Metadata file | Runtime host | Distribution |
+|-----------|---------------|--------------|--------------|
+| Collection | `collection/oneidentity/safeguard/galaxy.yml` | Ansible controller / execution node | Ansible Galaxy tarball |
+| Credential plugin | `credential_type_plugin/pyproject.toml` | AWX / AAP controller Python env | PyPI wheel / sdist |
+The two components are versioned and released independently.
+## 2. Authentication strategy and flow
+The repo supports two Safeguard auth models.
+### A2A / client certificate flow
+Used by:
+- `safeguardcredentials`
+- `safeguardcredentialtype`
+PySafeguard API:
+```python
+from pysafeguard import A2AContext, A2AType
+```
+Shared inputs:
+- `spp_appliance`
+- client certificate path
+- client private key path
+- API key for the retrievable credential
+- optional CA bundle / TLS toggle
+- credential type: `password` or `privatekey`
+Flow:
+1. Resolve TLS with `_resolve_verify()`.
+2. Normalize the requested type against `A2AType.PASSWORD` or
+   `A2AType.PRIVATEKEY`.
+3. Open an A2A session through PySafeguard.
+4. Retrieve the secret.
+5. Return `credential.value` from PySafeguard's `HiddenString`.
+The collection plugin keeps one `A2AContext(...)` open per lookup call so it can
+iterate over multiple API keys. The AWX plugin uses
+`A2AContext.quick_retrieve_password()` / `quick_retrieve_private_key()` because
+AWX resolves one credential at a time.
+### Access Request / PKCE flow
+Used only by `safeguardaccessrequest`.
+PySafeguard API:
+```python
+from pysafeguard import SafeguardClient, PkceAuth, Service
+```
+Inputs:
+- appliance host
+- provider name (`spp_provider`)
+- username and password
+- asset name or IP
+- optional account name
+- credential type (`password` or `privatekey`)
+- optional CA bundle / TLS toggle
+- optional checkout timeout
+Flow:
+1. Resolve options through Ansible's option system.
+2. Create `SafeguardClient(..., auth=PkceAuth(...), verify=verify)`.
+3. `client.login()`.
+4. Query `Me/RequestEntitlements`.
+5. Create or reuse an `AccessRequests` item.
+6. Poll checkout until success or timeout.
+7. Return the password string or the `PrivateKey` field from the SSH-key payload.
+The plugin intentionally does **not** check the credential back in after
+retrieval, because immediate check-in would rotate it and invalidate the value
+returned to Ansible.
+### TLS behavior
+All three plugin surfaces use the same `_resolve_verify()` shape:
+```python
+def _resolve_verify(tls_path, validate_certs=True):
+    if isinstance(tls_path, str) and tls_path:
+        return tls_path
+    if validate_certs:
+        return True
+    return False
+```
+That maps to three modes: explicit CA bundle, system CA validation, or disabled
+validation.
+## 3. Connection lifecycle
+### `safeguardcredentials`
+Per lookup invocation:
+1. `self.set_options(...)`
+2. read `a2aconnection`
+3. validate appliance / cert / key / type
+4. `with A2AContext(appliance, cert, key, verify=verify) as a2a:`
+5. loop over API-key terms
+6. call `retrieve_password()` or `retrieve_private_key()`
+7. append `.value` to the return list
+8. exit the context manager
+This is the only multi-key retrieval path in the repo.
+### `safeguardaccessrequest`
+Per lookup invocation:
+1. `self.set_options(...)`
+2. resolve direct kwargs, env vars, and ini values
+3. validate terms and auth inputs
+4. `with SafeguardClient(...) as client:`
+5. `client.login()`
+6. find entitlement
+7. create or reuse access request
+8. poll checkout endpoint
+9. return a single credential in a single-element list
+10. exit the client context
+There is no connection cache across tasks or plays.
+### `safeguardcredentialtype`
+Per AWX credential resolution:
+1. AWX discovers `spp_plugin`
+2. AWX renders `inputs.fields`
+3. AWX calls `_get_spp_credential(**kwargs)`
+4. the backend lazily imports PySafeguard
+5. it performs one A2A retrieval and returns a string
+The lazy import is deliberate: AWX can still import the plugin module even when
+`pysafeguard` is missing, and the error only appears when the backend runs.
+## 4. Key abstractions and their relationships
+### Main production abstractions
+| File | Main abstraction | Role |
+|------|------------------|------|
+| `safeguardcredentials.py` | `LookupModule(LookupBase)` | A2A lookup by API key |
+| `safeguardaccessrequest.py` | `LookupModule(LookupBase)` | Access Request checkout by asset/account |
+| `safeguardcredentialtype/__init__.py` | `CredentialPlugin(name, inputs, backend)` | AWX managed credential type |
+Shared production patterns:
+- `_resolve_verify()` translates user TLS options into PySafeguard's `verify`
+  parameter.
+- all retrieval paths normalize to two credential types: `password` and
+  `privatekey`.
+- `Display().vvvv(...)` is used for verbose diagnostics, not state management.
+### Credential-type mapping
+| Surface | Type source | Dispatch |
+|---------|-------------|----------|
+| A2A lookup | `A2AType.PASSWORD` / `A2AType.PRIVATEKEY` | `retrieve_password()` / `retrieve_private_key()` |
+| Access Request lookup | local `REQUEST_TYPES` + `CHECKOUT_ENDPOINTS` dicts | `CheckOutPassword` / `CheckOutSshKey` |
+| AWX credential plugin | UI field choice | `quick_retrieve_password()` / `quick_retrieve_private_key()` |
+If a new credential form is added, all three surfaces must change together.
+### Test-side support layer
+The collection test suite supplies most of the end-to-end support model:
+- `collection/tests/helpers/certificates.py` generates client certs, SSH keys,
+  and CA bundles
+- `collection/tests/helpers/provisioning.py` creates and deletes live SPP
+  objects
+- `collection/tests/conftest.py` provisions session fixtures and runs real
+  `ansible-playbook` subprocesses
+- `credential_type_plugin/tests/conftest.py` reuses collection test helpers by
+  adding `collection/tests` to `sys.path`
+That relationship matters: the repo keeps production code thin and encodes much
+of the integration behavior in fixtures and playbooks.
+## 5. Event system
+There is no event bus, callback plugin, or asynchronous worker system here.
+Architecture is synchronous request/response:
+- Ansible evaluates a lookup
+- the plugin opens a PySafeguard connection
+- the credential is returned
+- the context manager exits
+The closest thing to repeated background behavior is the fixed-interval checkout
+retry loop in `safeguardaccessrequest`, but it is still synchronous polling.
+## 6. Extension points
+### Add a new collection lookup plugin
+1. Add a file under `collection/oneidentity/safeguard/plugins/lookup/`.
+2. Implement `LookupModule(LookupBase)`.
+3. Add accurate `DOCUMENTATION`, `EXAMPLES`, and `RETURN` blocks.
+4. Reuse existing option names and `_resolve_verify()` behavior where possible.
+5. Add unit tests in `collection/tests/` and playbook-backed integration tests
+   in `collection/tests/playbooks/` when live behavior changes.
+6. Update collection docs in `collection/oneidentity/safeguard/README.md` and
+   repo guidance if the public surface changed.
+### Extend the AWX credential plugin
+1. Update `credential_type_plugin/safeguardcredentialtype/__init__.py`.
+2. Modify `spp_plugin.inputs.fields` / `inputs.required`.
+3. Keep sensitive fields marked `secret: True`.
+4. Preserve lazy PySafeguard import unless AWX discovery requirements change.
+5. Update `credential_type_plugin/tests/test_unit.py` and
+   `test_integration.py`.
+### Add a new credential type
+Update all coupled locations together:
+- A2A type normalization in `safeguardcredentials.py`
+- `REQUEST_TYPES` and `CHECKOUT_ENDPOINTS` in `safeguardaccessrequest.py`
+- AWX field choices and backend dispatch in `safeguardcredentialtype`
+- tests, playbooks, and docs for both components
+### Add another distributable component
+Follow the existing repository pattern:
+- keep packaging metadata at the component root
+- give the component its own tests and Azure pipeline
+- reuse `pipeline-templates/` and `versionnumber.ps1`
+- update `AGENTS.md` and this skill when the public surface changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,104 +1,147 @@
 # AGENTS.md — safeguard-ansible
 
-Ansible plugins for integrating with One Identity Safeguard for Privileged
-Passwords (SPP). Depends on the
-[PySafeguard](https://github.com/OneIdentity/PySafeguard) Python SDK (v8+).
+Ansible integrations for One Identity Safeguard for Privileged Passwords (SPP).
+This repo ships an Ansible Galaxy collection plus an AWX / AAP managed
+credential plugin. Both components depend on
+[PySafeguard](https://github.com/OneIdentity/PySafeguard) (`pysafeguard>=8,<9`).
 
-Requires Python ≥ 3.10. Requires Ansible ≥ 2.14.
+Requires Python ≥ 3.10 and Ansible ≥ 2.14.
 
 ## Project structure
 
 ```
 safeguard-ansible/
-├── AGENTS.md
-├── README.md
-├── LICENSE
-├── versionnumber.ps1                    # Version stamping script (dual-component)
-├── pipeline-templates/                  # Shared pipeline step templates
-├── collection/                          # Ansible Galaxy collection
-│   ├── azure-pipelines.yml
-│   ├── tests/                           # pytest: 32 unit + 21 integration
-│   │   ├── conftest.py                  # Session fixtures, playbook runner, auto-skip
-│   │   ├── helpers/                     # certificates.py, provisioning.py
-│   │   └── playbooks/                   # Ansible playbooks run by pytest
-│   └── oneidentity/safeguard/
-│       ├── galaxy.yml                   # Collection metadata (version source of truth)
-│       └── plugins/lookup/
-│           ├── safeguardcredentials.py   # A2A credential retrieval
-│           └── safeguardaccessrequest.py # Access Request credential retrieval
-└── credential_type_plugin/              # AWX/AAP credential type plugin
-    ├── azure-pipelines.yml
-    ├── pyproject.toml                   # PyPI packaging (version source of truth)
-    ├── tests/                           # pytest: 15 unit + 4 integration
-    └── safeguardcredentialtype/
-        └── __init__.py                  # AWX credential plugin implementation
+├── .agents/skills/                         # On-demand reference skills
+├── collection/
+│   ├── oneidentity/safeguard/
+│   │   ├── galaxy.yml                      # Collection metadata/version
+│   │   ├── meta/runtime.yml                # Ansible compatibility contract
+│   │   └── plugins/lookup/
+│   │       ├── safeguardcredentials.py     # A2A lookup plugin
+│   │       └── safeguardaccessrequest.py   # Access Request lookup plugin
+│   └── tests/                              # pytest + playbook-backed integration tests
+├── credential_type_plugin/
+│   ├── pyproject.toml                      # Packaging metadata + AWX entry point
+│   ├── safeguardcredentialtype/__init__.py # Managed credential implementation
+│   └── tests/
+├── pipeline-templates/                     # Shared Azure Pipelines templates
+└── versionnumber.ps1                       # Shared version stamping
 ```
 
-## Components
+Key public entry points:
 
-### Ansible Collection (`oneidentity.safeguardcollection`)
+- collection namespace: `oneidentity.safeguardcollection`
+- lookup plugins:
+  `oneidentity.safeguardcollection.safeguardcredentials` and
+  `oneidentity.safeguardcollection.safeguardaccessrequest`
+- AWX/AAP credential plugin entry point:
+  `awx.credential_plugins -> spp_plugin = safeguardcredentialtype:spp_plugin`
+- there are currently no Ansible modules under `plugins/modules`
 
-Two **lookup plugins** for retrieving credentials from SPP:
+## Setup and build
 
-- **safeguardcredentials** — A2A credential retrieval via client certificate.
-  Uses `pysafeguard.A2AContext`.
-- **safeguardaccessrequest** — Access Request workflow via username/password
-  (PKCE auth). Uses `pysafeguard.SafeguardClient` with `PkceAuth`.
+Install shared dependencies before validation:
 
-### Credential Type Plugin (`safeguardcredentialtype`)
+```bash
+python -m pip install "pysafeguard>=8,<9" pytest build twine
+python -m pip install ansible-core antsibull-changelog
+```
 
-A Python package that integrates with AWX / Ansible Automation Platform as a
-managed credential type. Entry point: `awx.credential_plugins` → `spp_plugin`.
-Published to PyPI.
-
-## Build commands
-
-### Collection
+Build commands:
 
 ```bash
 cd collection/oneidentity/safeguard
 ansible-galaxy collection build
-ansible-galaxy collection install oneidentity-safeguardcollection-<version>.tar.gz
+
+cd ../../../credential_type_plugin
+python -m build
 ```
 
-### Credential Type Plugin
+## Linting
+
+This repo has **implicit** linting only: there is no committed `ruff`, `flake8`,
+`ansible-lint`, or `pylint` config. Use packaging and tests as the quality gate.
+
+Expected validation:
+
+- collection: `python -m pytest collection/tests/test_unit.py -q` and
+  `cd collection/oneidentity/safeguard && ansible-galaxy collection build`
+- credential plugin:
+  `python -m pytest credential_type_plugin/tests/test_unit.py -q` and
+  `cd credential_type_plugin && python -m build && twine check dist/*`
+- keep YAML syntactically correct; there is no repo linter to catch bad
+  indentation or schema drift for you
+
+## Testing
+
+See `.agents/skills/testing-guide/SKILL.md` for the full matrix. Quick commands:
 
 ```bash
-cd credential_type_plugin
-python3 -m build
+python -m pytest collection/tests/test_unit.py -q
+python -m pytest credential_type_plugin/tests/test_unit.py -q
+python -m pytest collection/tests -q
+python -m pytest credential_type_plugin/tests -q
 ```
+
+Notes:
+
+- integration tests require a live SPP appliance and skip when `SPP_HOST` is unset
+- collection integration tests run real `ansible-playbook` subprocesses
+- both suites provision and clean up live SPP objects through PySafeguard
 
 ## Code conventions
 
-- Python ≥ 3.10 (no Python 2 compatibility shims)
-- Use explicit imports — no wildcard imports
-- 4-space indentation throughout
-- Ansible plugin conventions: `DOCUMENTATION`, `EXAMPLES`, `RETURN` module-level strings
-- reStructuredText-style docstrings (`:arg name:`, `:returns:`)
-- Copyright headers on all source files
-- `no_log: True` on options that contain secrets
-- Use `PkceAuth` for user authentication (not `PasswordAuth` — ROPC is disabled by default)
-- All test objects use `SgAns_` prefix with UUID suffix for identification and cleanup
+- Python ≥ 3.10 only; no Python 2 compatibility shims
+- use explicit imports and 4-space indentation
+- keep `DOCUMENTATION`, `EXAMPLES`, and `RETURN` accurate for lookup plugins
+- use reStructuredText-style docstrings (`:arg name:`, `:returns:`)
+- keep copyright headers on source files
+- mark secret-bearing options with `no_log: True` or AWX secret fields
+- use `PkceAuth`, not `PasswordAuth`
+- reuse the shared `_resolve_verify()` pattern for TLS-related options
+
+## CI/CD
+
+For pipeline layout, release triggers, publishing, and version stamping, see `.agents/skills/build-and-release/SKILL.md`.
+
+## Security
+
+- never commit appliance hostnames, API keys, passwords, private keys, CA bundles,
+  or exported AWX credential payloads
+- treat `spp_api_key`, `spp_password`, cert private keys, retrieved passwords,
+  and retrieved SSH keys as secrets at every layer
+- prefer environment variables or secure AWX fields over hardcoded examples
+- keep TLS verification enabled by default; disable it only for controlled test
+  environments with self-signed certs
+- when examples write SSH keys to disk, keep `mode: '0600'`, use `no_log: true`,
+  and document cleanup on the control node
 
 ## Versioning
 
-Both components use semantic versioning. The version in `galaxy.yml` and
-`pyproject.toml` is the source of truth. Component-prefixed git tags trigger
-official releases:
+Source-of-truth versions live in:
+
+- `collection/oneidentity/safeguard/galaxy.yml`
+- `credential_type_plugin/pyproject.toml`
+
+Release tags:
 
 - `collection-v<X.Y.Z>` → Ansible Galaxy
 - `credplugin-v<X.Y.Z>` → PyPI
 
-Do not manually edit version strings during builds — `versionnumber.ps1`
-handles dev suffixes for non-tag builds automatically.
+Do not hand-edit build-time dev suffixes; `versionnumber.ps1` computes them.
 
 ## On-demand skills
 
-The following skills contain reference material loaded only when relevant.
-Read the `SKILL.md` when your current task matches the trigger.
+Read these only when relevant:
 
 | Skill | When to read | File |
 |-------|-------------|------|
-| Testing Guide | Running tests, writing tests, investigating test failures, test environment setup | `.agents/skills/testing-guide/SKILL.md` |
-| PySafeguard API | Working on plugin source code, debugging credential retrieval, PySafeguard SDK usage | `.agents/skills/pysafeguard-api/SKILL.md` |
-| Build & Release | Preparing releases, modifying CI/CD pipelines, version management | `.agents/skills/build-and-release/SKILL.md` |
+| Architecture | Repository layout, plugin boundaries, auth flow, collection vs AWX plugin structure | `.agents/skills/architecture/SKILL.md` |
+| Testing Guide | Running tests, writing tests, or investigating failures | `.agents/skills/testing-guide/SKILL.md` |
+| PySafeguard API | Plugin code changes or SDK usage questions | `.agents/skills/pysafeguard-api/SKILL.md` |
+| Build & Release | CI/CD, versioning, or release work | `.agents/skills/build-and-release/SKILL.md` |
+
+## Keeping this file current
+
+Update this file when entry points, build/test commands, security expectations,
+CI triggers, or the skill inventory change.


### PR DESCRIPTION
Implements the skills harmonization plan:

- Created `architecture` skill (plugin architecture, collection structure, Ansible contracts, PySafeguard dependency)
- Updated AGENTS.md to standard template (security, linting, skill routing table)
- Normalized existing skill frontmatter

Part of cross-repo effort to standardize agent skills across all Safeguard SDK repositories.